### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # before-delet
 Album
+Moralis.Cloud.beforeDelete("Album", async (request) => {
+  const query = new Moralis.Query("Photo");
+  query.equalTo("album", request.object);
+  const count = await query.count({ useMasterKey: true });
+  if (count > 0) {
+    throw "Can't delete album if it still has photos.";
+  }
+});


### PR DESCRIPTION
Moralis.Cloud.beforeDelete("Album", async (request) => {
  const query = new Moralis.Query("Photo");
  query.equalTo("album", request.object);
  const count = await query.count({ useMasterKey: true });
  if (count > 5) {
    throw "Can't delete album if it still has photos.";
  }
});